### PR TITLE
Handling commands to unknown orders

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -63,4 +63,5 @@ akka {
 
 cqrs {
   maxOrderPrice = 100.00
+  uninitializedOrderLifeTime = 30 // seconds
 }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -63,5 +63,5 @@ akka {
 
 cqrs {
   maxOrderPrice = 100.00
-  uninitializedOrderLifeTime = 30 // seconds
+  orderReceiveTimeout = 30 seconds
 }

--- a/src/main/scala/cqrs/settings/Settings.scala
+++ b/src/main/scala/cqrs/settings/Settings.scala
@@ -1,7 +1,7 @@
 package cqrs.settings
 
 import akka.actor.{ Actor, ExtensionKey, Extension, ExtendedActorSystem }
-import scala.concurrent.duration.{ Duration, FiniteDuration }
+import scala.concurrent.duration._
 import java.util.concurrent.TimeUnit
 
 object Settings extends ExtensionKey[Settings]
@@ -12,6 +12,7 @@ class Settings(system: ExtendedActorSystem) extends Extension {
   val config = system.settings.config getConfig ("cqrs")
 
   val maxOrderPrice: Double = config getDouble "maxOrderPrice"
+  val uninitializedOrderLifeTime: Duration = config getInt "uninitializedOrderLifeTime" seconds
 }
 
 /*

--- a/src/main/scala/cqrs/settings/Settings.scala
+++ b/src/main/scala/cqrs/settings/Settings.scala
@@ -1,8 +1,7 @@
 package cqrs.settings
 
 import akka.actor.{ Actor, ExtensionKey, Extension, ExtendedActorSystem }
-import scala.concurrent.duration._
-import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.{ Duration, SECONDS }
 
 object Settings extends ExtensionKey[Settings]
 
@@ -12,7 +11,7 @@ class Settings(system: ExtendedActorSystem) extends Extension {
   val config = system.settings.config getConfig ("cqrs")
 
   val maxOrderPrice: Double = config getDouble "maxOrderPrice"
-  val uninitializedOrderLifeTime: Duration = config getInt "uninitializedOrderLifeTime" seconds
+  val orderReceiveTimeout: Duration = Duration(config.getDuration("orderReceiveTimeout", SECONDS), SECONDS)
 }
 
 /*

--- a/src/test/scala/cqrs/SystemTest.scala
+++ b/src/test/scala/cqrs/SystemTest.scala
@@ -16,7 +16,8 @@ class SystemTest extends TestKit(ActorSystem("systemtest")) with ImplicitSender 
 
   override def afterAll(): Unit = system.shutdown()
 
-  lazy val orders = system.actorOf(Orders.props, "Orders")
+  lazy val orders = system.actorOf(Orders.props(orderRegion), "Orders")
+
   // Stub out the orderRegion with a local implementation
   val orderRegion = actor {
     new Act {

--- a/src/test/scala/cqrs/domain/orders/DomainTest.scala
+++ b/src/test/scala/cqrs/domain/orders/DomainTest.scala
@@ -2,7 +2,6 @@ package cqrs
 package domain.orders
 
 import java.util.UUID
-import cqrs.domain.orders.OrderCommandHandler.UnknownOrderException
 
 import scala.concurrent.duration._
 import org.scalatest.{ BeforeAndAfterAll, Matchers, FlatSpecLike }
@@ -15,6 +14,8 @@ import akka.testkit.{ TestProbe, ImplicitSender, TestKit }
 import Order.MaxOrderPriceReached
 import read.OrdersView
 import settings.Settings
+
+import OrderCommandHandler.UnknownOrderException
 
 class DomainTest extends TestKit(ActorSystem("domain")) with FlatSpecLike with ImplicitSender with Matchers with BeforeAndAfterAll {
 


### PR DESCRIPTION
Created a new event for `Order`, in order to avoid manipulating uninitialized orders. After some configurable threshold, the uninitialized orders automatically stop themselves in order to not litter the cluster with unnecessary actors. Also the initialization command is sent from the command handler when the order is created, or even if the order was already registered in the `Orders` singleton, to avoid consistency issues when restarting the system, entry relocation, network partition, etc. Added some tests to check correctness also.
